### PR TITLE
Changing references for the example template

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Ironman** is a CLI tool that provides an easy way to create and share project templates hosted in git repositories, for any programming language or document based project. Install and generate a new project based on an **Ironman Template** in seconds.  
 
-## Why would I care ?
+## Why would I care?
 
 Let’s say you are about to start a new cool project, you need a common project directories structure, a few dozens of files,  every time you have to change README titles/subtitles, specific app identifiers, documentation URL’s and so on to get started.  What if you work with one or many teams and you want to provide an easy way to share common project templates and enforce common development good practices and standards.  How would you solve this repetitive task ? 
 

--- a/acceptance/features/install.feature
+++ b/acceptance/features/install.feature
@@ -5,10 +5,10 @@ Feature: Install a template
   I need to run the install command 
 
   Scenario: Install a template with correct URL
-    When It runs with correct URL "https://github.com/ottogiron/wizard-hello-world.git"
+    When It runs with correct URL "https://github.com/ironman-project/template-example.git"
     Then The process state should be success 
     And The output should contain "Installing template" and "done"
-    And A template should be installed with ID "wizard-hello-world"
+    And A template should be installed with ID "template-example"
    
   Scenario: Install a template with unreachable URL 
     When It runs with unreachable URL "http://hola"

--- a/acceptance/features/list.feature
+++ b/acceptance/features/list.feature
@@ -5,7 +5,7 @@ Feature: List Available Templates
   I need to run the list command
 
   Scenario: List available templates
-    Given A template to list is installed with URL "https://github.com/ottogiron/wizard-hello-world.git"
+    Given A template to list is installed with URL "https://github.com/ironman-project/template-example.git"
     When List runs 
     Then The List process state should be success 
     And The List output should contain "Installed templates" and 
@@ -13,7 +13,7 @@ Feature: List Available Templates
 +--------------------+--------------------+-------------+
 |         ID         |        NAME        | DESCRIPTION |
 +--------------------+--------------------+-------------+
-| wizard-hello-world | wizard-hello-world | TODO        |
+| template-example   | template-example   | TODO        |
 +--------------------+--------------------+-------------+
 """
 

--- a/acceptance/features/uninstall.feature
+++ b/acceptance/features/uninstall.feature
@@ -5,11 +5,11 @@ Feature: Uninstall a template
   I need to run the Uninstall command 
 
   Scenario: Uninstalling a template with correct ID
-    Given A template to uninstall URL "https://github.com/ottogiron/wizard-hello-world.git"
-    When It runs with correct ID "wizard-hello-world"
+    Given A template to uninstall URL "https://github.com/ironman-project/template-example.git"
+    When It runs with correct ID "template-example"
     Then The Uninstall process state should be success 
     And The Uninstall output should contain "Uninstallinging template" and "done"
-    And An Uninstalled template with ID "wizard-hello-world" should not exists
+    And An Uninstalled template with ID "template-example" should not exists
   
 
   

--- a/acceptance/features/update.feature
+++ b/acceptance/features/update.feature
@@ -5,7 +5,7 @@ Feature: Update a template
   I need to run the Update command 
 
     Scenario: Update a template with an ID
-    Given A template is installed with URL "https://github.com/ottogiron/wizard-hello-world.git"
-    When Update runs with correct template ID "wizard-hello-world"
+    Given A template is installed with URL "https://github.com/ironman-project/template-example.git"
+    When Update runs with correct template ID "template-example"
     Then The Update process state should be success 
-    And The Update output should contain "Updating template wizard-hello-world" and "done"
+    And The Update output should contain "Updating template template-example" and "done"

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -26,7 +26,7 @@ var installCmd = &cobra.Command{
 	Long: `Installs a template using a git URL:
 
 Example:
-iroman install https://github.com/ottogiron/wizard-hello-world.git
+iroman install https://github.com/ironman-project/template-example.git
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		templateURL := args[0]

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -21,7 +21,7 @@ ironman list
 +--------------------+--------------------+-------------+
 |         ID         |        NAME        | DESCRIPTION |
 +--------------------+--------------------+-------------+
-| wizard-hello-world | wizard-hello-world | TODO        |
+| template-example   | template-example   | TODO        |
 +--------------------+--------------------+-------------+
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/template/repository/git/git_test.go
+++ b/template/repository/git/git_test.go
@@ -28,14 +28,14 @@ func TestRepository_Install(t *testing.T) {
 	}{
 		{
 			"Install template",
-			args{"https://github.com/ottogiron/wizard-hello-world.git"},
-			"wizard-hello-world",
-			[]string{".xwizard.yml"},
+			args{"https://github.com/ironman-project/template-example.git"},
+			"template-example",
+			[]string{".ironman.yml"},
 			false,
 		},
 		{
 			"Install unexisting template",
-			args{"https://github.com/ottogiron/unexisting-template"},
+			args{"https://github.com/ironman-project/unexisting-template"},
 			"",
 			[]string{},
 			true,
@@ -81,7 +81,7 @@ func TestRepository_Update(t *testing.T) {
 	}{
 		{
 			"Update template",
-			args{"wizard-hello-world", "https://github.com/ottogiron/wizard-hello-world.git"},
+			args{"template-example", "https://github.com/ironman-project/template-example.git"},
 			false,
 		},
 	}


### PR DESCRIPTION
We should use a template-example who resides inside this organization.

I created a replica of the olde one [here](https://github.com/ironman-project/template-example) and I also changed all the references inside the ironman tests.

Builds are passing:
- [appveyor](https://ci.appveyor.com/project/ottogiron/ironman/build/build-32.change-example-template-references)
- [travis](https://travis-ci.org/ironman-project/ironman/builds/330209529)